### PR TITLE
Use vendored version of utoipa-swagger-ui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3568,8 +3568,15 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa",
+ "utoipa-swagger-ui-vendored",
  "zip 1.1.4",
 ]
+
+[[package]]
+name = "utoipa-swagger-ui-vendored"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20d6689d3a5693eec4d21f6b9d7c54f37468b856da8e98a7bb316f7b32df6e3"
 
 [[package]]
 name = "uuid"

--- a/rtz/Cargo.toml
+++ b/rtz/Cargo.toml
@@ -84,7 +84,7 @@ tower-http = { version = "0.5.2", features = ["full"], optional = true }
 http = { version = "1.1.0", optional = true }
 http-body-util = { version = "0.1.2", optional = true }
 utoipa = { version = "4.0.0", features = ["axum_extras"], optional = true }
-utoipa-swagger-ui = { version = "7.1.0", features = ["axum"], optional = true }
+utoipa-swagger-ui = { version = "7.1.0", features = ["axum", "vendored"], optional = true }
 utoipa-redoc = { version = "4.0.0", features = ["axum"], optional = true }
 utoipa-rapidoc = { version = "4.0.0", features = ["axum"], optional = true }
 


### PR DESCRIPTION
Without the `vendored` feature, `utoipa-swagger-ui` build script retrieves the swagger-ui files at build time. This requires network access when building rtz, even when Rust dependencies have been vendored.